### PR TITLE
fix(validators): change signature to match parameter, exported from main package

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import * as exportNonTypes from "./index";
 describe("Library index - export non-type", () => {
   it('Should export only "PredicateTree" non type thing', () => {
-    expect(Object.keys(exportNonTypes).length).toBe(9);
+    expect(Object.keys(exportNonTypes).length).toBe(10);
 
     expect("CONSTS" in exportNonTypes).toBeTruthy();
     expect("EXAMPLE_JSON_BLUE_SKIES" in exportNonTypes).toBeTruthy();
@@ -13,6 +13,7 @@ describe("Library index - export non-type", () => {
     expect("PredicateTree" in exportNonTypes).toBeTruthy();
     expect("PredicateTreeError" in exportNonTypes).toBeTruthy();
     expect("PredicateTreeFactory" in exportNonTypes).toBeTruthy();
+    expect("Validators" in exportNonTypes).toBeTruthy();
   });
   it("Should not have undefined exports", () => {
     // sometimes coverage shows index 0, this test helps - I don't understand why

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
 import type { TSerializedPredicateTree, IVisitor } from "./Predicates";
 
 import type { IPredicateTree } from "./Predicates/PredicateTree";
+import { Validators } from "./validators";
 
 import type {
   TOperatorOptions,
@@ -54,6 +55,7 @@ export {
   PredicateTreeFactory,
   PredicateSubjectDictionary,
   PredicateSubjectDictionaryFactory,
+  Validators,
 };
 
 export type {

--- a/src/validators/NoSingleChildRule.ts
+++ b/src/validators/NoSingleChildRule.ts
@@ -1,12 +1,8 @@
-import { IValidator } from "./types";
+import { TValidatorResponse } from "./types";
 import { PredicateTree } from "../index";
 import { TreeVisitors } from "../Predicates/TreeVisitors";
 
-export const myValidator: IValidator = (x: any, y: any) => {
-  return { hasError: false, errorMessages: [] };
-};
-
-export const NoSingleChildRule = (pTree: PredicateTree) => {
+export const NoSingleChildRule = (pTree: PredicateTree): TValidatorResponse => {
   const branchIdVisitor = new TreeVisitors.PredicateIdsBranches();
   pTree.acceptVisitor(branchIdVisitor);
 

--- a/src/validators/ValidateAllPredicatesAgainstOperator.ts
+++ b/src/validators/ValidateAllPredicatesAgainstOperator.ts
@@ -1,4 +1,4 @@
-import { IValidator, TValidatorResponse } from "./types";
+import { TValidatorResponse } from "./types";
 import type { IPredicateSubjectDictionary } from "../index";
 import { TSerializedPredicateTree } from "../Predicates";
 import { isValidJunctionPredicate } from "./isFunctions";

--- a/src/validators/ValidateAllPredicatesAgainstOperator.ts
+++ b/src/validators/ValidateAllPredicatesAgainstOperator.ts
@@ -1,13 +1,13 @@
-import { IValidator } from "./types";
+import { IValidator, TValidatorResponse } from "./types";
 import type { IPredicateSubjectDictionary } from "../index";
 import { TSerializedPredicateTree } from "../Predicates";
 import { isValidJunctionPredicate } from "./isFunctions";
 import { ValidatePredicateAgainstOperator } from "./ValidatePredicateAgainstOperator";
 
-export const ValidateAllPredicatesAgainstOperator: IValidator = (
+export const ValidateAllPredicatesAgainstOperator = (
   predicateTreeJson: TSerializedPredicateTree,
   subjectDictionary: IPredicateSubjectDictionary
-) => {
+): TValidatorResponse => {
   const allErrorMessages: string[] = [];
 
   Object.entries(predicateTreeJson).forEach(([nodeId, predicateNode]) => {

--- a/src/validators/ValidatePredicateAgainstOperator.ts
+++ b/src/validators/ValidatePredicateAgainstOperator.ts
@@ -13,9 +13,16 @@ import {
   isNumeric,
   isString,
 } from "./isFunctions";
-import { IValidator } from "./types";
+import { IValidator, TValidatorResponse } from "./types";
 
-export const ValidatePredicateAgainstOperator: IValidator = (
+interface IValidatePredicateAgainstOperator {
+  (
+    predicateJson: TPredicateNodeJson,
+    subjects: IPredicateSubjectDictionary
+  ): TValidatorResponse;
+}
+
+export const ValidatePredicateAgainstOperator: IValidatePredicateAgainstOperator = (
   predicateJson: TPredicateNodeJson,
   subjects: IPredicateSubjectDictionary
 ) => {

--- a/src/validators/ValidateSubjectDictionary.ts
+++ b/src/validators/ValidateSubjectDictionary.ts
@@ -1,11 +1,10 @@
 import { TPredicateSubjectDictionaryJson } from "../PredicateSubjects";
-import { IValidator } from "./types";
+import { TValidatorResponse } from "./types";
 import { ValidatePredicateSubject } from "./ValidatePredicateSubject";
 
-//const x:  TPredicateSubjectDictionaryJson
-export const ValidateSubjectDictionary: IValidator = (
+export const ValidateSubjectDictionary = (
   subjects: TPredicateSubjectDictionaryJson
-) => {
+): TValidatorResponse => {
   const allErrors: string[] = [];
   if (Object.keys(subjects || {}).length === 0) {
     allErrors.push("Subject Dictionary has no subjects");

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -2,12 +2,10 @@ import { NoSingleChildRule } from "./NoSingleChildRule";
 import { ValidateAllPredicatesAgainstOperator } from "./ValidateAllPredicatesAgainstOperator";
 import { ValidatePredicateAgainstOperator } from "./ValidatePredicateAgainstOperator";
 import { ValidateSubjectDictionary } from "./ValidateSubjectDictionary";
-// import { IsValidPredicateOperator } from "./IsValidPredicateOperator";
 
 export const Validators = {
   ValidateAllPredicatesAgainstOperator,
   NoSingleChildRule,
   ValidatePredicateAgainstOperator,
   ValidateSubjectDictionary,
-  //  IsValidPredicateOperator,
 };


### PR DESCRIPTION
Signature were implementing generic interface, removed that so actual parameter list would be shown
in IDE

fix #13
https://github.com/terary/gabby-query-protocol-lib/issues/13


CHANGELOG 
- revised Validators signatures. removed generic interface so parameters would be visible in IDE
- Exported visitors from main package 