### PR TITLE
feat(ivisitorpredicatetree): Expose Visitor functionality.

### DIFF
--- a/examples/ExampleVisitors.ts
+++ b/examples/ExampleVisitors.ts
@@ -1,0 +1,44 @@
+import { PredicateFormulaEditorFactory, TPredicateProperties } from "../src";
+import { EXAMPLE_JSON_BLUE_SKIES } from "../src";
+
+const { predicateTreeJson } = EXAMPLE_JSON_BLUE_SKIES;
+const { predicateSubjectsDictionaryJson: subjectDictionaryJson } =
+  EXAMPLE_JSON_BLUE_SKIES;
+
+export const predicateFormula = PredicateFormulaEditorFactory.fromJson({
+  predicateTreeJson: predicateTreeJson,
+  subjectDictionaryJson: subjectDictionaryJson,
+});
+
+import type { IVisitorPredicateTree, TPredicateNode, VisitorNodeType } from "../src";
+
+class BranchIdVisitor implements IVisitorPredicateTree {
+  private _startBrachId: string;
+  private _branchIds: string[] = [];
+
+  constructor(startBranchId: string) {
+    this._startBrachId = startBranchId;
+  }
+
+  get startNodeId() {
+    return this._startBrachId;
+  }
+  visit(parentId: string, nodeId: string, payload: TPredicateNode) {
+    this._branchIds.push(nodeId);
+  }
+
+  get nodeType(): VisitorNodeType {
+    return "branch";
+  }
+
+  get branchIds() {
+    return this._branchIds;
+  }
+}
+
+const branchVisitor = new BranchIdVisitor(predicateFormula.rootNodeId);
+
+predicateFormula.predicatesAcceptVisitor(branchVisitor);
+// predicateFormula.predicateTree.acceptVisitor(branchSwitcher);
+
+console.log(branchVisitor.branchIds);

--- a/examples/ExampleVisitorsPredicateTreeGeneral.ts
+++ b/examples/ExampleVisitorsPredicateTreeGeneral.ts
@@ -1,16 +1,17 @@
-import { PredicateFormulaEditorFactory, TPredicateProperties } from "../src";
+import { PredicateFormulaEditorFactory } from "../src";
+import type { IVisitorPredicateTree, TPredicateNode, VisitorNodeType } from "../src";
 import { EXAMPLE_JSON_BLUE_SKIES } from "../src";
 
 const { predicateTreeJson } = EXAMPLE_JSON_BLUE_SKIES;
 const { predicateSubjectsDictionaryJson: subjectDictionaryJson } =
   EXAMPLE_JSON_BLUE_SKIES;
 
-export const predicateFormula = PredicateFormulaEditorFactory.fromJson({
+const predicateFormula = PredicateFormulaEditorFactory.fromJson({
   predicateTreeJson: predicateTreeJson,
   subjectDictionaryJson: subjectDictionaryJson,
 });
 
-import type { IVisitorPredicateTree, TPredicateNode, VisitorNodeType } from "../src";
+// see also Specialized Example
 
 class BranchIdVisitor implements IVisitorPredicateTree {
   private _startBrachId: string;
@@ -37,8 +38,5 @@ class BranchIdVisitor implements IVisitorPredicateTree {
 }
 
 const branchVisitor = new BranchIdVisitor(predicateFormula.rootNodeId);
-
 predicateFormula.predicatesAcceptVisitor(branchVisitor);
-// predicateFormula.predicateTree.acceptVisitor(branchSwitcher);
-
 console.log(branchVisitor.branchIds);

--- a/examples/ExampleVisitorsPredicateTreeSpecialized.ts
+++ b/examples/ExampleVisitorsPredicateTreeSpecialized.ts
@@ -1,0 +1,58 @@
+import { PredicateFormulaEditorFactory, TPredicateProperties } from "../src";
+import type { IVisitor, VisitorNodeType } from "../src";
+import { EXAMPLE_JSON_BLUE_SKIES } from "../src";
+
+const { predicateTreeJson } = EXAMPLE_JSON_BLUE_SKIES;
+const { predicateSubjectsDictionaryJson: subjectDictionaryJson } =
+  EXAMPLE_JSON_BLUE_SKIES;
+
+const predicateFormula = PredicateFormulaEditorFactory.fromJson({
+  predicateTreeJson: predicateTreeJson,
+  subjectDictionaryJson: subjectDictionaryJson,
+});
+
+/**
+ * IVisitor<TPredicateProperties>           -> nodeType = 'leaf'
+ * IVisitor<TPredicatePropertiesArrayValue> -> nodeType = 'leaf'
+ * IVisitor<TPredicatePropertiesJunction>   -> nodeType = 'branch'
+ * IVisitor<TPredicateNode>                 -> nodeType = 'branch' | 'leaf' | 'all'
+ *
+ * IVisitor<TPredicateNode> is aliased as IVisitorPredicateTree
+ * see General example
+ */
+
+class SpecializedVisitor implements IVisitor<TPredicateProperties> {
+  // by using IVisitor<TPredicateProperties> our payload will
+  // will also be TPredicateProperties,
+  // which is helpful for IDE code-assist and type checking
+  private _startBrachId: string;
+  private _leafIds: string[] = [];
+  private _leafSubjectIds: string[] = [];
+
+  constructor(startBranchId: string) {
+    this._startBrachId = startBranchId;
+  }
+
+  get startNodeId() {
+    return this._startBrachId;
+  }
+  visit(parentId: string, nodeId: string, payload: TPredicateProperties) {
+    this._leafIds.push(nodeId);
+    this._leafSubjectIds.push(payload.subjectId);
+  }
+
+  get nodeType(): VisitorNodeType {
+    return "leaf";
+  }
+
+  get leafIds() {
+    return this._leafIds;
+  }
+  get leafSubjectIds() {
+    return this._leafSubjectIds;
+  }
+}
+const specializedVisitor = new SpecializedVisitor(predicateFormula.rootNodeId);
+predicateFormula.predicatesAcceptVisitor(specializedVisitor);
+console.log(specializedVisitor.leafIds);
+console.log(specializedVisitor.leafSubjectIds);

--- a/src/PredicateFormulaEditor/PredicateFormulaEditor.ts
+++ b/src/PredicateFormulaEditor/PredicateFormulaEditor.ts
@@ -22,7 +22,7 @@ import {
   PredicateTreeFactory,
 } from "../index";
 import { PredicateTreeError } from "../Predicates/PredicateTree/PredicateTreeError";
-import type { TPredicateTreeFactoryOptions } from "../Predicates";
+import type { IVisitor, TPredicateTreeFactoryOptions } from "../Predicates";
 
 export class PredicateFormulaEditor
   implements IExportToJson<PredicateFormulaEditor, PredicateFormulaEditorJson>
@@ -47,7 +47,10 @@ export class PredicateFormulaEditor
     return this._predicateSubjectDictionary;
   }
 
-  predicatesAcceptVisitor(visitor: IVisitorPredicateTree): void {
+  predicatesAcceptVisitor(visitor: IVisitorPredicateTree | IVisitor<any>): void {
+    // don't love the IVisitor<any>,  but I think its probably safe.
+    // using 'TPredicateNode' causes issue when trying to implement with TPredicateProperties.
+
     this._predicateTree.acceptVisitor(visitor);
   }
 

--- a/src/PredicateFormulaEditor/PredicateFormulaEditor.ts
+++ b/src/PredicateFormulaEditor/PredicateFormulaEditor.ts
@@ -4,7 +4,7 @@ import type {
   TPredicateSubjectAsColumnDefinition,
   TPredicateSubjectOptionsList,
   TPredicateSubjectWithId,
-  IVisitor,
+  IVisitorPredicateTree,
   TPredicateJunctionPropsWithChildIds,
   TPredicateProperties,
   TPredicatePropertiesArrayValue,
@@ -47,7 +47,7 @@ export class PredicateFormulaEditor
     return this._predicateSubjectDictionary;
   }
 
-  predicatesAcceptVisitor(visitor: IVisitor<TPredicateNode>): void {
+  predicatesAcceptVisitor(visitor: IVisitorPredicateTree): void {
     this._predicateTree.acceptVisitor(visitor);
   }
 

--- a/src/Predicates/PredicateTree/IPredicateTree.ts
+++ b/src/Predicates/PredicateTree/IPredicateTree.ts
@@ -6,10 +6,10 @@ import type {
   TSerializedPredicateTree,
 } from "../../index";
 //import { IDirectedTreeGraph } from "../DirectedTreeGraph/IDirectedTreeGraph";
-import type { IVisitor } from "../index";
+import type { IVisitorPredicateTree } from "../index";
 
 export interface IPredicateTree {
-  acceptVisitor(visitor: IVisitor<TPredicateNode>): void;
+  acceptVisitor(visitor: IVisitorPredicateTree): void;
 
   appendPredicate(parentId: string, predicate: TPredicateNode): string;
 

--- a/src/Predicates/PredicateTree/IVisitorPredicateTree.ts
+++ b/src/Predicates/PredicateTree/IVisitorPredicateTree.ts
@@ -1,0 +1,4 @@
+import type { IVisitor } from "../DirectedTreeGraph";
+import type { TPredicateNode } from "../../index";
+
+export interface IVisitorPredicateTree extends IVisitor<TPredicateNode> {}

--- a/src/Predicates/PredicateTree/PredicateTree.test.ts
+++ b/src/Predicates/PredicateTree/PredicateTree.test.ts
@@ -12,7 +12,6 @@ import { simplePredicates } from "./test-helpers";
 import predicateTreeJson from "../../test-case-files/predicate-tree-blue-skies.json";
 import { TSerializedPredicateTree } from "..";
 import { TreeVisitors } from "../TreeVisitors";
-// import { VisitorOperatorCounter } from "../TreeVisitors/VisitorOperatorCounter";
 import { PredicateTreeError } from "./PredicateTreeError";
 
 const VisitorOperatorCounter = TreeVisitors.OperatorCounter;

--- a/src/Predicates/PredicateTree/PredicateTree.ts
+++ b/src/Predicates/PredicateTree/PredicateTree.ts
@@ -33,7 +33,7 @@ import {
   DirectedTreeGraph,
   SerializedTree,
 } from "../DirectedTreeGraph";
-import type { IVisitor, VisitorNodeType } from "../index";
+import type { IVisitorPredicateTree } from "../index";
 import type {
   TPredicateJunctionPropsWithChildIds,
   TPredicatePropertiesJunction,
@@ -61,7 +61,7 @@ export default class PredicateTree implements IPredicateTree {
   get defaultJunction(): TPredicatePropertiesJunction {
     return { ...this._defaultJunction };
   }
-  acceptVisitor(visitor: IVisitor<TPredicateNode>): void {
+  acceptVisitor(visitor: IVisitorPredicateTree): void {
     this._tree.accept(visitor);
   }
 

--- a/src/Predicates/PredicateTree/PredicateTreeFactory.test.ts
+++ b/src/Predicates/PredicateTree/PredicateTreeFactory.test.ts
@@ -5,9 +5,6 @@ import subjectDictionaryJson from "../../test-case-files/harden-cases/subject-di
 import { TSerializedPredicateTree } from "..";
 import { TPredicateSubjectDictionaryJson } from "../../index";
 import { PredicateSubjectDictionaryFactory } from "../../PredicateSubjects";
-import { VisitorTreeToJson } from "../DirectedTreeGraph/VisitorTreeToJson";
-import { format } from "prettier";
-import { isMapIterator } from "util/types";
 import { assert } from "console";
 
 const predicateTreeJson = cloneDeep(

--- a/src/Predicates/PredicateTree/index.ts
+++ b/src/Predicates/PredicateTree/index.ts
@@ -3,7 +3,7 @@ import PredicateTree from "./PredicateTree";
 import { PredicateTreeFactory } from "./PredicateTreeFactory";
 import type { IPredicateTree } from "./IPredicateTree";
 import type { TPredicateTreeFactoryOptions } from "./PredicateTreeFactory";
-
-export type { IPredicateTree, TPredicateTreeFactoryOptions };
+import type { IVisitorPredicateTree } from "./IVisitorPredicateTree";
+export type { IPredicateTree, TPredicateTreeFactoryOptions, IVisitorPredicateTree };
 
 export { PredicateTree, PredicateTreeFactory };

--- a/src/Predicates/TreeVisitors/OperatorCounter.ts
+++ b/src/Predicates/TreeVisitors/OperatorCounter.ts
@@ -5,14 +5,15 @@
 
 import { CONSTS } from "../../common";
 import type { TPredicateNode } from "../../index";
+import type { IVisitorPredicateTree } from "../PredicateTree/IVisitorPredicateTree";
 
 import { TPredicateOperator, TPredicateJunctionOperator } from "../../PredicateSubjects";
-import type { VisitorNodeType, IVisitor } from "../index";
+import type { VisitorNodeType } from "../index";
 
 const SUPPORTED_OPERATORS = CONSTS.JUNCTION_OPERATORS.concat(CONSTS.PREDICATE_OPERATORS);
 
 type ValidOpTypes = TPredicateOperator | TPredicateJunctionOperator;
-export class OperatorCounter implements IVisitor<TPredicateNode> {
+export class OperatorCounter implements IVisitorPredicateTree {
   private _operatorCounts: {
     [key in ValidOpTypes]?: number;
   } = {};
@@ -26,11 +27,6 @@ export class OperatorCounter implements IVisitor<TPredicateNode> {
   visit(parentId: string, nodeId: string, payload: TPredicateNode) {
     this._operatorCounts[payload.operator] =
       (this._operatorCounts[payload.operator] || 0) + 1;
-    // if (this._operatorCounts[payload.operator] === undefined) {
-    //   this._operatorCounts[payload.operator] = 0;
-    // } else {
-    //   this._operatorCounts[payload.operator] = (this._operatorCounts[payload.operator] || 0) + 1;
-    // }
   }
 
   get nodeType(): VisitorNodeType {

--- a/src/Predicates/TreeVisitors/PredicateIdsAbstract.ts
+++ b/src/Predicates/TreeVisitors/PredicateIdsAbstract.ts
@@ -3,10 +3,10 @@
  *
  */
 import type { TPredicateNode } from "../../index";
+import type { IVisitorPredicateTree } from "../PredicateTree";
+import type { VisitorNodeType } from "../index";
 
-import type { VisitorNodeType, IVisitor } from "../index";
-
-export abstract class PredicateIdsAbstract implements IVisitor<TPredicateNode> {
+export abstract class PredicateIdsAbstract implements IVisitorPredicateTree {
   protected _predicateIds: string[] = [];
   protected _nodeType: VisitorNodeType;
   constructor() {

--- a/src/Predicates/TreeVisitors/PredicateIdsBranches.ts
+++ b/src/Predicates/TreeVisitors/PredicateIdsBranches.ts
@@ -1,5 +1,3 @@
-import type { TPredicateNode } from "../../index";
-import type { VisitorNodeType, IVisitor } from "../index";
 import { PredicateIdsAbstract } from "./PredicateIdsAbstract";
 
 export class PredicateIdsBranches extends PredicateIdsAbstract {

--- a/src/Predicates/index.ts
+++ b/src/Predicates/index.ts
@@ -1,7 +1,7 @@
 import { PredicateTree, PredicateTreeFactory } from "./PredicateTree";
 import { PredicateTreeError } from "./PredicateTree/PredicateTreeError";
 import { TPredicateNode } from "../common/type";
-import type { SerializedTree, VisitorNodeType } from "./DirectedTreeGraph";
+import type { SerializedTree, VisitorNodeType, IVisitor } from "./DirectedTreeGraph";
 import type { TPredicateTreeFactoryOptions } from "./PredicateTree";
 import type { IVisitorPredicateTree } from "./PredicateTree";
 export { PredicateTree, PredicateTreeFactory, PredicateTreeError };
@@ -10,6 +10,7 @@ export { PredicateTree, PredicateTreeFactory, PredicateTreeError };
 type TSerializedPredicateTree = SerializedTree<TPredicateNode>;
 
 export type {
+  IVisitor,
   IVisitorPredicateTree,
   SerializedTree as TSerializedTree,
   TPredicateTreeFactoryOptions,

--- a/src/Predicates/index.ts
+++ b/src/Predicates/index.ts
@@ -1,16 +1,16 @@
 import { PredicateTree, PredicateTreeFactory } from "./PredicateTree";
 import { PredicateTreeError } from "./PredicateTree/PredicateTreeError";
 import { TPredicateNode } from "../common/type";
-import type { IVisitor, SerializedTree, VisitorNodeType } from "./DirectedTreeGraph";
+import type { SerializedTree, VisitorNodeType } from "./DirectedTreeGraph";
 import type { TPredicateTreeFactoryOptions } from "./PredicateTree";
-
+import type { IVisitorPredicateTree } from "./PredicateTree";
 export { PredicateTree, PredicateTreeFactory, PredicateTreeError };
 
 // moving away from 'serialized[something]' toward '[something]Json'
 type TSerializedPredicateTree = SerializedTree<TPredicateNode>;
 
 export type {
-  IVisitor,
+  IVisitorPredicateTree,
   SerializedTree as TSerializedTree,
   TPredicateTreeFactoryOptions,
   TSerializedPredicateTree,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,11 @@ import {
   PredicateSubjectDictionary,
   PredicateSubjectDictionaryFactory,
 } from "./PredicateSubjects";
-import type { TSerializedPredicateTree, IVisitorPredicateTree } from "./Predicates";
+import type {
+  TSerializedPredicateTree,
+  IVisitorPredicateTree,
+  IVisitor,
+} from "./Predicates";
 
 import type { IPredicateTree } from "./Predicates/PredicateTree";
 import { Validators } from "./validators";
@@ -61,6 +65,7 @@ export {
 export type {
   IPredicateSubjectDictionary,
   IPredicateTree, // to be used instead of PredicateTree
+  IVisitor,
   IVisitorPredicateTree,
   TOperatorOptions,
   PredicateFormulaEditorJson,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
   PredicateSubjectDictionary,
   PredicateSubjectDictionaryFactory,
 } from "./PredicateSubjects";
-import type { TSerializedPredicateTree, IVisitor } from "./Predicates";
+import type { TSerializedPredicateTree, IVisitorPredicateTree } from "./Predicates";
 
 import type { IPredicateTree } from "./Predicates/PredicateTree";
 import { Validators } from "./validators";
@@ -61,7 +61,7 @@ export {
 export type {
   IPredicateSubjectDictionary,
   IPredicateTree, // to be used instead of PredicateTree
-  IVisitor,
+  IVisitorPredicateTree,
   TOperatorOptions,
   PredicateFormulaEditorJson,
   TPredicateJunctionPropsWithChildIds,


### PR DESCRIPTION



CHANGELOG
- Created example, how to use IVisitor<T>
- Created example, how to use IVisitorPredicateTree
- Aliased IVisitor<TPredicateNode> as IVisitorPredicateTree
- Expose any/all necessary functionality to use Visitors


#2, #3, #12