### PR TITLE
Predicate formula editor empty tree

### DIFF
--- a/src/PredicateFormulaEditor/PredicateFormulaEditor.test.ts
+++ b/src/PredicateFormulaEditor/PredicateFormulaEditor.test.ts
@@ -12,9 +12,10 @@ import { PredicateFormulaEditor } from "./PredicateFormulaEditor";
 import { VisitorNodeCounter } from "../Predicates/DirectedTreeGraph/VisitorNodeCounter";
 import { Validators } from "../validators";
 import { TPredicateSubjectDictionaryJson } from "../PredicateSubjects";
+import { predicateFormula } from "../../examples";
 
 describe("PredicateFormulaEditor", () => {
-  it("Should be create formula without issue (smoke test)", () => {
+  it("Should be create formula editor without issue (smoke test)", () => {
     const predicateFormulaEditor = PredicateFormulaEditorFactory.fromJson(
       blueSkiesJson as PredicateFormulaEditorJson
     );
@@ -31,6 +32,66 @@ describe("PredicateFormulaEditor", () => {
       predicateFormulaEditor.rootNodeId
     );
     expect(predicateChildren).toStrictEqual(["flatFileTest:0", "flatFileTest:1"]);
+  });
+  it("Should be create formula editor, predicate tree optional", () => {
+    const predicateFormulaEditor = PredicateFormulaEditorFactory.fromJson({
+      subjectDictionaryJson:
+        blueSkiesJson.subjectDictionaryJson as TPredicateSubjectDictionaryJson,
+    });
+    expect(predicateFormulaEditor.subjectsGetAllIds().sort()).toStrictEqual(
+      [
+        "firstName",
+        "isEmptySubject",
+        "isNullSubject",
+        "lastName",
+        "notEqualSubject",
+      ].sort()
+    );
+
+    const predicate = predicateFormulaEditor.predicatesGetPropertiesById(
+      predicateFormulaEditor.rootNodeId
+    );
+    const predicateChildren = predicateFormulaEditor.predicatesGetChildrenIds(
+      predicateFormulaEditor.rootNodeId
+    );
+
+    expect(predicate.operator).toBeDefined();
+    expect(predicate.subjectId).toBeDefined();
+    expect(predicate.value).toBeDefined();
+
+    expect(predicateChildren).toStrictEqual([]);
+  });
+  it(".fromJson Should throw error if json elements are undefined", () => {
+    const willThrow = () => {
+      const predicateFormulaEditor = PredicateFormulaEditorFactory.fromJson(
+        {} as PredicateFormulaEditorJson
+      );
+    };
+    expect(willThrow).toThrow(
+      "Can not build tree from undefined subjection dictionary json."
+    );
+    expect(willThrow).toThrow(PredicateTreeError);
+  });
+  it(".fromJson Should throw error if json is undefined", () => {
+    const willThrow = () => {
+      const predicateFormulaEditor = PredicateFormulaEditorFactory.fromJson(
+        //@ts-ignore
+        undefined as PredicateFormulaEditorJson
+      );
+    };
+    expect(willThrow).toThrow("Can not build tree from undefined json.");
+    expect(willThrow).toThrow(PredicateTreeError);
+  });
+  it(".fromEmpty Should throw error if json is undefined", () => {
+    const willThrow = () => {
+      const predicateFormulaEditor = PredicateFormulaEditorFactory.fromEmpty(
+        {} as PredicateFormulaEditorJson
+      );
+    };
+    expect(willThrow).toThrow(
+      "Build tree failed due to subjection dictionary errors. See debug messages for more details"
+    );
+    expect(willThrow).toThrow(PredicateTreeError);
   });
   it("Should be create formula editor with empty tree  without issue (smoke test)", () => {
     //
@@ -233,6 +294,11 @@ describe("PredicateFormulaEditor", () => {
       const subjectDictionary = predicateFormulaEditor.subjectDictionary;
       expect(subjectDictionary.constructor.name).toBe("PredicateSubjectDictionary");
     });
+    it(".subjectGetColumns() - should return subjects with type", () => {
+      const columns = predicateFormulaEditor.subjectGetColumns();
+      expect(columns).toStrictEqual(columnsBlueSkies);
+    });
+
     it("getOptionsList calls subjectDictionary.getOptionsList", () => {
       expect(predicateFormulaEditor.subjectsGetOptionsList("ANY_WILL_DO")).toStrictEqual({
         $anyOf: [],
@@ -261,3 +327,31 @@ describe("PredicateFormulaEditor", () => {
     });
   }); //describe('Wrapped Methods',
 });
+
+const columnsBlueSkies = [
+  {
+    subjectId: "firstName",
+    datatype: "string",
+    defaultLabel: "First Name",
+  },
+  {
+    subjectId: "lastName",
+    datatype: "string",
+    defaultLabel: "Last Name",
+  },
+  {
+    subjectId: "isNullSubject",
+    datatype: "string",
+    defaultLabel: "Can be null",
+  },
+  {
+    subjectId: "notEqualSubject",
+    datatype: "string",
+    defaultLabel: "Can be not equal",
+  },
+  {
+    subjectId: "isEmptySubject",
+    datatype: "string",
+    defaultLabel: "Can be empty",
+  },
+];

--- a/src/PredicateFormulaEditor/PredicateFormulaEditor.ts
+++ b/src/PredicateFormulaEditor/PredicateFormulaEditor.ts
@@ -23,7 +23,6 @@ import {
 } from "../index";
 import { PredicateTreeError } from "../Predicates/PredicateTree/PredicateTreeError";
 import type { IVisitor, TPredicateTreeFactoryOptions } from "../Predicates";
-import { ValidatePredicateSubject } from "../validators/ValidatePredicateSubject";
 import { ValidateSubjectDictionary } from "../validators/ValidateSubjectDictionary";
 
 export class PredicateFormulaEditor

--- a/src/PredicateFormulaEditor/PredicateFormulaEditorFactory.test.ts
+++ b/src/PredicateFormulaEditor/PredicateFormulaEditorFactory.test.ts
@@ -3,6 +3,9 @@ import { PredicateFormulaEditor } from "./PredicateFormulaEditor";
 import type { PredicateFormulaEditorJson } from "./types";
 import { blueSkiesJson } from "../test-case-files/harden-cases";
 import { TPredicateSubjectDictionaryJson } from "../PredicateSubjects";
+import { predicateFormula } from "../../examples";
+import { TPredicateProperties } from "../common";
+import { PredicateTreeError } from "../Predicates";
 
 describe("PredicateFormulaEditor", () => {
   it("Should call fromJson", () => {
@@ -10,9 +13,14 @@ describe("PredicateFormulaEditor", () => {
     const willThrow = () => {
       PredicateFormulaEditorFactory.fromJson({} as PredicateFormulaEditorJson);
     };
-    expect(willThrow).toThrow("Cannot convert undefined or null to object");
+
+    expect(willThrow).toThrow(PredicateTreeError);
+    expect(willThrow).toThrow(
+      "Can not build tree from undefined subjection dictionary json."
+    );
     expect(fromJsonSpy).toBeCalled();
   });
+
   it("Should call fromEmpty", () => {
     const fromJsonSpy = jest.spyOn(PredicateFormulaEditor, "fromEmpty");
     PredicateFormulaEditorFactory.fromEmpty(
@@ -30,5 +38,25 @@ describe("PredicateFormulaEditor", () => {
     PredicateFormulaEditorFactory.toJson(PredicateFormulaEditor);
 
     expect(fromJsonSpy).toBeCalled();
+  });
+
+  it("Should allow undefined predicate tree", () => {
+    const PredicateFormulaEditor = PredicateFormulaEditorFactory.fromJson({
+      subjectDictionaryJson:
+        blueSkiesJson.subjectDictionaryJson as TPredicateSubjectDictionaryJson,
+    });
+
+    const predicateTree = PredicateFormulaEditor.predicateTree;
+    const rootNodeId = PredicateFormulaEditor.rootNodeId;
+    const childrenIds = predicateTree.getChildrenIds(rootNodeId);
+    const rootNode = predicateTree.getPredicateById(rootNodeId) as TPredicateProperties;
+
+    expect(childrenIds).toStrictEqual([]);
+    expect(rootNode.operator).toBeDefined();
+    expect(rootNode.subjectId).toBeDefined();
+    expect(rootNode.value).toBeDefined();
+
+    const fromJsonSpy = jest.spyOn(PredicateFormulaEditor, "toJson");
+    PredicateFormulaEditorFactory.toJson(PredicateFormulaEditor);
   });
 });

--- a/src/PredicateFormulaEditor/PredicateFormulaEditorFactory.test.ts
+++ b/src/PredicateFormulaEditor/PredicateFormulaEditorFactory.test.ts
@@ -3,7 +3,6 @@ import { PredicateFormulaEditor } from "./PredicateFormulaEditor";
 import type { PredicateFormulaEditorJson } from "./types";
 import { blueSkiesJson } from "../test-case-files/harden-cases";
 import { TPredicateSubjectDictionaryJson } from "../PredicateSubjects";
-import { predicateFormula } from "../../examples";
 import { TPredicateProperties } from "../common";
 import { PredicateTreeError } from "../Predicates";
 

--- a/src/PredicateFormulaEditor/PredicateFormulaEditorFactory.ts
+++ b/src/PredicateFormulaEditor/PredicateFormulaEditorFactory.ts
@@ -2,35 +2,25 @@ import { PredicateFormulaEditor } from "./PredicateFormulaEditor";
 import type { PredicateFormulaEditorJson } from "./types";
 import type { TPredicateSubjectDictionaryJson } from "../PredicateSubjects";
 import type { TPredicateTreeFactoryOptions } from "../Predicates";
-export namespace PredicateFormulaEditorFactory {
-  // TODO - *tmc* - probably more sensible to have
-  // fromJson({x:TSubjectDictionary, y?:predicateTree})
-  // and determine which to call, fromEmpty or fromJson
-  //
-  // TODO - *tmc* - do away with namespace.
-  //  try something like const x: {fromJson:IImporter<jsonType,outType = ()=>{....}}
-  //  *maybe* you can implement the import/export interfaces and create static class type thing
-  //
-  export function fromEmpty(
+
+export const PredicateFormulaEditorFactory = {
+  fromEmpty: (
     subjectDictionaryJson: TPredicateSubjectDictionaryJson,
     options?: TPredicateTreeFactoryOptions
-  ): PredicateFormulaEditor {
+  ): PredicateFormulaEditor => {
     return PredicateFormulaEditor.fromEmpty(subjectDictionaryJson, options);
-  }
+  },
 
-  export function fromJson(
+  fromJson: (
     json: PredicateFormulaEditorJson,
     options?: TPredicateTreeFactoryOptions
-  ): PredicateFormulaEditor {
-    // if (json.predicateTreeJson === undefined) {
-    //   return PredicateFormulaEditor.fromEmpty(json.subjectDictionaryJson, options);
-    // }
+  ): PredicateFormulaEditor => {
     return PredicateFormulaEditor.fromJson(json, options);
-  }
+  },
 
-  export function toJson(
+  toJson: (
     predicateFormulaEditor: PredicateFormulaEditor
-  ): PredicateFormulaEditorJson {
+  ): PredicateFormulaEditorJson => {
     return predicateFormulaEditor.toJson();
-  }
-}
+  },
+};

--- a/src/PredicateFormulaEditor/PredicateFormulaEditorFactory.ts
+++ b/src/PredicateFormulaEditor/PredicateFormulaEditorFactory.ts
@@ -22,6 +22,9 @@ export namespace PredicateFormulaEditorFactory {
     json: PredicateFormulaEditorJson,
     options?: TPredicateTreeFactoryOptions
   ): PredicateFormulaEditor {
+    // if (json.predicateTreeJson === undefined) {
+    //   return PredicateFormulaEditor.fromEmpty(json.subjectDictionaryJson, options);
+    // }
     return PredicateFormulaEditor.fromJson(json, options);
   }
 

--- a/src/PredicateFormulaEditor/types.ts
+++ b/src/PredicateFormulaEditor/types.ts
@@ -1,5 +1,5 @@
 import type { TPredicateSubjectDictionaryJson, TSerializedPredicateTree } from "../index";
 export type PredicateFormulaEditorJson = {
-  predicateTreeJson: TSerializedPredicateTree;
+  predicateTreeJson?: TSerializedPredicateTree;
   subjectDictionaryJson: TPredicateSubjectDictionaryJson;
 };

--- a/src/Predicates/PredicateTree/PredicateTreeFactory.ts
+++ b/src/Predicates/PredicateTree/PredicateTreeFactory.ts
@@ -8,7 +8,6 @@ export type TPredicateTreeFactoryOptions = {
   newRootId?: string;
 };
 
-// TODO - *tmc* - This should be using namespace
 export const PredicateTreeFactory = {
   fromEmpty: (
     subjectDictionary: IPredicateSubjectDictionary,

--- a/src/Predicates/PredicateTree/PredicateTreeFactory.ts
+++ b/src/Predicates/PredicateTree/PredicateTreeFactory.ts
@@ -25,6 +25,7 @@ export const PredicateTreeFactory = {
 
     return predicateTree;
   },
+
   fromJson: (
     json: TSerializedPredicateTree,
     subjectDictionary: IPredicateSubjectDictionary,
@@ -58,6 +59,7 @@ export const PredicateTreeFactory = {
 
     return predicateTree;
   },
+
   toJson: (tree: IPredicateTree): TSerializedPredicateTree => {
     return tree.toJson();
   },


### PR DESCRIPTION



CHANGELOG
- converted factory from namespace to constant
- made predicateTreeJson optional for factories (https://github.com/terary/gabby-query-protocol-lib/issues/10) 