### PR TITLE
Fix tpredicateproperties

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,10 @@
     "projectables",
     "testables"
   ],
-  
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/node_modules/*/**": true,
+    "**/.hg/store/**": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gabby-query-protocol-lib",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "description": "Library Support for the Gabby Query Protocol",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gabby-query-protocol-lib",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0-beta.1",
   "description": "Library Support for the Gabby Query Protocol",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/common/type.ts
+++ b/src/common/type.ts
@@ -15,7 +15,9 @@ type TPredicateProperties = {
   // determined by the subject definition {subjectId, validOps, datatype...}
 };
 
-type TPredicatePropertiesArrayValue = TPredicateProperties & {
+type TPredicatePropertiesArrayValue = {
+  subjectId: string;
+  operator: TPredicateOperator;
   value: (number | string)[];
 };
 


### PR DESCRIPTION
PredicateProperities was defined with conflicting values making it impossible to use.
Basically a typeo or logic error. 
`TPredicateProperties = {... value: number|string}`
`TPredicatePropertiesArrayValue = TPredicateProperties & {... value: (number|string)[]}`,
compiler interpret as simultaneously; `value: (number|string) &  (number|string)[]`
